### PR TITLE
remove deprecated arguments from rock_init

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.0)
+project(base VERSION 1.0)
 find_package(Rock)
-rock_init(base 1.0)
+rock_init()
 
 set(CMAKE_CXX_STANDARD 11)
 


### PR DESCRIPTION
Installation w/ colcon yielded the following warning.

```
--- stderr: base-logging                              
CMake Warning at /home/freki/ros/rock_ws/install/base-cmake/share/rock/cmake/Rock.cmake:113 (message):
  Passing project name and version to rock_init was a misfeature of Rock's
  macros since CMake 3.0.  You must call CMake's project() at toplevel, like
  this:

  project(base-logging VERSION 0.1 DESCRIPTION "project description")

  Remove the arguments to rock_init() to silence this warning
Call Stack (most recent call first):
  CMakeLists.txt:5 (rock_init)


---
Finished <<< base-logging [2.04s]
```

Thus the rock_init() argument was moved to project().

Furthermore, the VERSION argument was only introduced in CMake 3.0. Thus the cmake_minimum_version had to be increased to 3.0
https://cmake.org/cmake/help/v3.0/policy/CMP0048.html#policy:CMP0048